### PR TITLE
feat: Modify Gallery Selection

### DIFF
--- a/parSta_App_SwiftData_DetailView/Account/UserProfileView.swift
+++ b/parSta_App_SwiftData_DetailView/Account/UserProfileView.swift
@@ -54,25 +54,14 @@ struct UserProfileView: View {
                 .cancel()
             ])
         }
-        .sheet(isPresented: $showPhotosPicker) {
-            ZStack {
-                // 이미지 크롭 기능 - 추후 업데이트
-                // ImageEditorView(inputImage: $selectedImageData, showPhotosPicker: $showPhotosPicker)
-                
-                PhotosPicker(selection: $selectedImage, matching: .images) {
-                    Text("Select a photo")
-                }
-                .zIndex(1)
-//                .offset(y: UIScreen.main.bounds.height / 3)
-                .onChange(of: selectedImage) { _, image in
-                    Task {
-                        if let data = try? await image?.loadTransferable(type: Data.self) {
-                            selectedImageData = data
-                            UserDefaults.standard.set(data, forKey: "profileImage")
-                            
-                            self.showPhotosPicker = false
-                        }
-                    }
+        .photosPicker(isPresented: $showPhotosPicker, selection: $selectedImage)
+        .onChange(of: selectedImage) { _, image in
+            Task {
+                if let data = try? await image?.loadTransferable(type: Data.self) {
+                    selectedImageData = data
+                    UserDefaults.standard.set(data, forKey: "profileImage")
+                    
+                    self.showPhotosPicker = false
                 }
             }
         }


### PR DESCRIPTION
사용자 프로필 사진 변경시 갤러리 이벤트 수정
- 기존: 갤러리 이미지로 변경 클릭시 액션시트가 올라오며 'select image`버튼을 한번 더 눌러야 하는 번거로움이 있음
- 수정: 갤러리 이미지로 변경 클릭시 즉시 갤러리가 오픈되어 프로필 이미지 변경 가능